### PR TITLE
make compatible with revealjs version 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,24 @@
 
 1. Copy the file `mapbox-gl.js` into the plugin folder of your reveal.js presentation, i.e. `plugin/mapbox-gl`.
 
-2. Add the plugins to the dependencies in your presentation
+2. Add script imports
+
+```html
+<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.js"></script>
+<script src="plugin/mapbox-gl/mapbox-gl.js"></script>
+```
+
+3. Add the plugin name to the `plugins` in your presentation
 
 ```javascript
 Reveal.initialize({
 	// ...
-	dependencies: [
-		// ...
-		{ src: 'https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.js' },
-		{ src: 'plugin/mapbox-gl/mapbox-gl.js'},
-		// ...
-	],
+	plugins: [ RevealMapbox ],
+	// ...
 	mapbox: {accessToken: "YOUR ACCESS TOKEN"}
 });
 ```
-3. Add CSS import
+4. Add CSS import
 ```html
 <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.css' rel='stylesheet' />
 ```

--- a/mapbox-gl.js
+++ b/mapbox-gl.js
@@ -3,7 +3,12 @@
  *
  * @author Tomas Lipovsky
  */
-var RevealMapbox = window.RevealMapbox || (function(){
+window.RevealMapbox = window.RevealMapbox || {
+    id: 'RevealMapbox',
+    init: function(deck) { initMapbox(deck) }
+};
+
+const initMapbox = function(Reveal){
 
 	var options = Reveal.getConfig().mapbox || {};
 	options.accessToken = options.accessToken || 'undefined'
@@ -106,4 +111,4 @@ var RevealMapbox = window.RevealMapbox || (function(){
 			return;
 		goCurrentMapPosition();
 	} );
-})();
+};


### PR DESCRIPTION
Found this plugin the other day and it was exactly what I was after - unfortunately it didn't work with the latest major version. In particular, `dependencies` has been [deprecated](https://revealjs.com/plugins/#dependencies).

This change updates both the js and the documentation to be compatible with revealjs v4.x.